### PR TITLE
write both ascii and binary formart

### DIFF
--- a/IOPositionOld/IOPositionOld.C
+++ b/IOPositionOld/IOPositionOld.C
@@ -62,10 +62,34 @@ bool Foam::IOPositionOld<CloudType>::writeData(Ostream& os) const
 {
     os  << cloud_.size() << nl << token::BEGIN_LIST << nl;
 
-    forAllConstIter(typename CloudType, cloud_, iter)
+    if (os.format() == IOstream::ASCII)
     {
-        os  << iter().position() << " " << iter().cell()
-            << nl;
+        forAllConstIter(typename CloudType, cloud_, iter)
+        {
+            os  << iter().position() << " " << iter().cell()
+                << nl;
+        }
+    }
+    else
+    {
+        const size_t sizeofPositionCompat =
+        (
+            offsetof(positionsCompat, facei)
+            - offsetof(positionsCompat, position)
+        );
+
+        forAllConstIter(typename CloudType, cloud_, iter)
+        {
+            positionsCompat p;
+            p.position = iter().position();
+            p.celli = iter().cell();
+            os.write
+            (
+                reinterpret_cast<const char*>(&p.position),
+                sizeofPositionCompat
+            );
+            os  << nl;
+        }
     }
 
     os  << token::END_LIST << endl;

--- a/IOPositionOld/IOPositionOld.H
+++ b/IOPositionOld/IOPositionOld.H
@@ -63,6 +63,19 @@ class IOPositionOld
 
 public:
 
+    //- Old particle positions content for OpenFOAM-5/OpenFOAM-1706 and earlier
+    struct positionsCompat
+    {
+        vector position;
+        label celli;
+        label facei;
+        scalar stepFraction;
+        label tetFacei;
+        label tetPti;
+        label origProc;
+        label origId;
+    };
+
     // Static data
 
         //- Runtime type name information. Use cloud type.


### PR DESCRIPTION
Dear author,

I am [ZmengXu](https://github.com/ZmengXu), I have made a little bit change to your code to make it compatible for a binary format data.

In most of the big cases, OpenFOAM data is written as a binary format. However, the current utility only writes the ASCII position, thus we have a compatible issue for the binary format.

I wrote a judgment, as suggested in OpenFOAM-1806, to make it compatible for both ASCII and binary formats. I have tested in both OF6 and OF7, it works fine. Please see the code difference in the pull request.

By the way, the ParaView-OpenFOAM-binary reader module only recognizes the 'Int32' version OpenFOAM data, which is a common issue for ParaView. Therefore, for the 'Int64' OpenFOAM binary data, the only solution is to use paraFoam instead of ParaView, since paraFoam know the size of "label" is 32bit or 64bit, but ParaView doesn't know.

[ZmengXu](https://github.com/ZmengXu)
Department of Energy Sciences
Lund University, 22100 Lund, Sweden.
Email:[shijiexu2010@gmail.com](mailto:shijiexu2010@gmail.com)